### PR TITLE
fix(audit_log.models.fields.LastUserField): fixed missing `on_delete`…

### DIFF
--- a/audit_log/models/fields.py
+++ b/audit_log/models/fields.py
@@ -9,62 +9,73 @@ class LastUserField(models.ForeignKey):
     A field that keeps the last user that saved an instance
     of a model. None will be the value for AnonymousUser.
     """
-    
-    def __init__(self, to = getattr(settings, 'AUTH_USER_MODEL', 'auth.User'), null = True, editable = False,  **kwargs):
-        super(LastUserField, self).__init__(to = to, null = null, editable = editable, **kwargs)
-    
+
+    def __init__(self, to=getattr(settings, 'AUTH_USER_MODEL', 'auth.User'), null=True, editable=False,  **kwargs):
+        on_delete = kwargs.pop('on_delete', models.PROTECT)
+
+        super(LastUserField, self).__init__(
+            to=to, on_delete=on_delete, null=null, editable=editable, **kwargs)
+
     def contribute_to_class(self, cls, name):
         super(LastUserField, self).contribute_to_class(cls, name)
         registry = registration.FieldRegistry(self.__class__)
         registry.add_field(cls, self)
 
+
 class LastSessionKeyField(models.CharField):
     """
     A field that keeps a reference to the last session key that was used to access the model.
     """
-    
-    def __init__(self, max_length  = 40, null = True, editable = False,  **kwargs):
-        super(LastSessionKeyField, self).__init__(max_length = 40, null = null, editable = editable, **kwargs)
-    
+
+    def __init__(self, max_length=40, null=True, editable=False,  **kwargs):
+        super(LastSessionKeyField, self).__init__(
+            max_length=40, null=null, editable=editable, **kwargs)
+
     def contribute_to_class(self, cls, name):
         super(LastSessionKeyField, self).contribute_to_class(cls, name)
         registry = registration.FieldRegistry(self.__class__)
         registry.add_field(cls, self)
+
 
 class CreatingUserField(LastUserField):
     """
     A field that keeps track of the user that created a model instance.
     This will only be set once upon an INSERT in the database.
     """
-    #dont actually need to do anything, everything is handled by the parent class
-    #the different logic goes in the middleware
+    # dont actually need to do anything, everything is handled by the parent class
+    # the different logic goes in the middleware
     pass
+
 
 class CreatingSessionKeyField(LastSessionKeyField):
     """
     A field that keeps track of the last session key with which a model instance was created.
     This will only be set once upon an INSERT in the database.
     """
-    #dont actually need to do anything, everything is handled by the parent class
-    #the different logic goes in the middleware
+    # dont actually need to do anything, everything is handled by the parent class
+    # the different logic goes in the middleware
     pass
 
 
-#South stuff:
+# South stuff:
 
 rules = [((LastUserField, CreatingUserField),
-    [],    
-    {   
-        'to': ['rel.to', {'default': getattr(settings, 'AUTH_USER_MODEL', 'auth.User')}],
-        'null': ['null', {'default': True}],
-    },)]
+          [],
+          {
+    'to': ['rel.to', {'default': getattr(settings, 'AUTH_USER_MODEL', 'auth.User')}],
+    'null': ['null', {'default': True}],
+},)]
 
 try:
     from south.modelsinspector import add_introspection_rules
     # Add the rules for the `LastUserField`
-    add_introspection_rules(rules, ['^audit_log\.models\.fields\.LastUserField'])
-    add_introspection_rules(rules, ['^audit_log\.models\.fields\.CreatingUserField'])
-    add_introspection_rules([], ['^audit_log\.models\.fields\.LastSessionKeyField'])
-    add_introspection_rules([], ['^audit_log\.models\.fields\.CreatingSessionKeyField'])
+    add_introspection_rules(
+        rules, ['^audit_log\.models\.fields\.LastUserField'])
+    add_introspection_rules(
+        rules, ['^audit_log\.models\.fields\.CreatingUserField'])
+    add_introspection_rules(
+        [], ['^audit_log\.models\.fields\.LastSessionKeyField'])
+    add_introspection_rules(
+        [], ['^audit_log\.models\.fields\.CreatingSessionKeyField'])
 except ImportError:
     pass

--- a/audit_log/models/managers.py
+++ b/audit_log/models/managers.py
@@ -165,15 +165,26 @@ class AuditLog(object):
                     field._unique = False
                     field.db_index = True
 
-
-                if field.rel and field.rel.related_name:
-                    field.rel.related_name = '_auditlog_%s' % field.rel.related_name                
-                elif field.rel: 
-                    try:
-                        if field.rel.get_accessor_name():
-                            field.rel.related_name = '_auditlog_%s' % field.rel.get_accessor_name()
-                    except:
-                        pass
+                if hasattr(field, 'rel'):
+                    # Django <= 1.9
+                    if field.rel and field.rel.related_name:
+                        field.rel.related_name = '_auditlog_%s' % field.rel.related_name
+                    elif field.rel:
+                        try:
+                            if field.rel.get_accessor_name():
+                                field.rel.related_name = '_auditlog_%s' % field.rel.get_accessor_name()
+                        except:
+                            pass
+                else:
+                    # Django 2.x
+                    if field.remote_field and field.remote_field.related_name:
+                        field.remote_field.related_name = '_auditlog_%s' % field.remote_field.related_name
+                    elif field.remote_field:
+                        try:
+                            if field.remote_field.get_accessor_name():
+                                field.remote_field.related_name = '_auditlog_%s' % field.remote_field.get_accessor_name()
+                        except:
+                            pass
   
                 fields[field.name] = field
 


### PR DESCRIPTION
… positional argument error in d

Django 2.x has a required positional argument named `on_delete` in django.db.models.ForeignKey which
is missing in the current implementation of audit_log. This commit provides a work around by adding
a key word argument of the same name in the required position.